### PR TITLE
Deploy benchrunner to AWS

### DIFF
--- a/.github/workflows/_generate.yml
+++ b/.github/workflows/_generate.yml
@@ -1,0 +1,45 @@
+---
+name: _generate
+
+"on":
+  workflow_call:
+    inputs:
+      force:
+        type: boolean
+        default: false
+      dry_run:
+        type: boolean
+        default: false
+
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Regenerate all of the derived data, even if it already exists"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run: Do not commit to the repo"
+        type: boolean
+        default: false
+
+jobs:
+  generate-results:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: install dependencies
+        run:
+          python -m pip install -r requirements.txt
+      - name: regenerate
+        run:
+          python -m bench_runner.scripts.generate_results ${{ inputs.force == true && '--force' || '' }}
+      - name: Add to repo
+        uses: EndBug/add-and-commit@v9
+        if: ${{ !inputs.dry_run }}
+        with:
+          add: "['results', 'README.md', 'RESULTS.md', 'longitudinal.png', 'profiling/profiling.png', 'profiling/profiling.md']"
+          message: Benchmarking results for @${{ github.actor }}

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -1,0 +1,50 @@
+---
+name: _publish
+
+"on":
+  workflow_call:
+    inputs:
+      force:
+        type: boolean
+        default: false
+      dry_run:
+        type: boolean
+        default: false
+
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Regenerate all of the derived data, even if it already exists"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run: Do not commit to the repo"
+        type: boolean
+        default: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: private
+          ref: main
+          fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          path: public
+          ref: main
+          repository: faster-cpython/benchmarking-public
+          token: ${{ secrets.BENCHMARK_MIRROR }}
+      - name: Mirror
+        run: |
+          cd public
+          git remote add upstream $PWD/../private
+          git fetch upstream
+          git reset --hard upstream/main
+      - name: Push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          cd public
+          git push origin main

--- a/.github/workflows/benchrunner-aws.yml
+++ b/.github/workflows/benchrunner-aws.yml
@@ -1,0 +1,19 @@
+name: Deploy benchrunner to AWS
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository to the runner
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2

--- a/.github/workflows/benchrunner-aws.yml
+++ b/.github/workflows/benchrunner-aws.yml
@@ -17,3 +17,13 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
+
+      - name: Set Up Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Start EC2 instance Using Terraform Configuration
+        run: |
+          cd terraform
+          terraform init
+          terraform apply -auto-approve
+

--- a/.github/workflows/benchrunner-aws.yml
+++ b/.github/workflows/benchrunner-aws.yml
@@ -1,7 +1,7 @@
 name: Deploy benchrunner to AWS
 
 on:
-  workflow_dispatch: {}
+  [push]
 
 jobs:
   deploy:

--- a/.github/workflows/benchrunner-aws.yml
+++ b/.github/workflows/benchrunner-aws.yml
@@ -1,7 +1,10 @@
 name: Deploy benchrunner to AWS
 
 on:
-  [push]
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,18 @@ pyembed_includes
 .cache/
 build_cinderx_venv/
 CinderX/build/
+
+# Ignore Terraform state files, directories, and logs
+*.tfstate
+*.tfstate.*
+*.terraform
+*.terraform.*
+.terraform/
+terraform.log
+
+# Ignore sensitive or auto-generated files
+*.pem
+*.key
+*.tfvars
+*.tfvars.*
+

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ terraform.log
 *.tfvars
 *.tfvars.*
 
+# Ignore venv directory
+venv/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/faster-cpython/bench_runner@v0.2.2#egg=bench_runner

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "This is a test file was created during the instance initialization." > test.txt

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = "us-west-2"
+}
+
+resource "aws_instance" "app_server" {
+  ami           = "ami-830c94e3"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "ExampleAppServerInstance"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-west-2"
+  region = "us-west-2"
 }
 
 resource "aws_instance" "app_server" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,6 +85,7 @@ resource "aws_instance" "bench_runner" {
   key_name               = "bench-runner"
   vpc_security_group_ids = ["${aws_security_group.ingress_all.id}"]
   subnet_id              = aws_subnet.subnet1.id
+  user_data              = file("init.sh")
 
   tags = {
     Name = "BenchmarkingEC2Runner"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,11 +13,81 @@ provider "aws" {
   region = "us-west-2"
 }
 
-resource "aws_instance" "app_server" {
-  ami           = "ami-830c94e3"
-  instance_type = "t2.micro"
+resource "aws_vpc" "bench_run" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
 
   tags = {
-    Name = "ExampleAppServerInstance"
+    Name = "bench_run"
   }
 }
+
+resource "aws_eip" "bench_run_ip" {
+  instance = aws_instance.bench_runner.id
+  vpc      = true
+}
+
+resource "aws_internet_gateway" "bench_run_gw" {
+  vpc_id = aws_vpc.bench_run.id
+
+  tags = {
+    Name = "bench_run_gw"
+  }
+}
+
+resource "aws_subnet" "subnet1" {
+  cidr_block        = cidrsubnet(aws_vpc.bench_run.cidr_block, 3, 1)
+  vpc_id            = aws_vpc.bench_run.id
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_route_table" "bench_run_route_table" {
+  vpc_id = aws_vpc.bench_run.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.bench_run_gw.id
+  }
+
+  tags = {
+    Name = "bench_run_route_table"
+  }
+}
+
+resource "aws_route_table_association" "subnet_association" {
+  subnet_id      = aws_subnet.subnet1.id
+  route_table_id = aws_route_table.bench_run_route_table.id
+}
+
+resource "aws_security_group" "ingress_all" {
+  name   = "allow_all_sg"
+  vpc_id = aws_vpc.bench_run.id
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+  }
+}
+
+resource "aws_instance" "bench_runner" {
+  ami                    = "ami-830c94e3"
+  instance_type          = "t2.micro"
+  key_name               = "bench-runner"
+  vpc_security_group_ids = ["${aws_security_group.ingress_all.id}"]
+  subnet_id              = aws_subnet.subnet1.id
+
+  tags = {
+    Name = "BenchmarkingEC2Runner"
+  }
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,10 +79,15 @@ resource "aws_security_group" "ingress_all" {
   }
 }
 
+resource "aws_key_pair" "benchrun_keypair" {
+  key_name   = "bench-runner"
+  public_key = file("~/.ssh/id_rsa.pub")
+}
+
 resource "aws_instance" "bench_runner" {
   ami                    = "ami-830c94e3"
   instance_type          = "t2.micro"
-  key_name               = "bench-runner"
+  key_name               = aws_key_pair.benchrun_keypair.key_name
   vpc_security_group_ids = ["${aws_security_group.ingress_all.id}"]
   subnet_id              = aws_subnet.subnet1.id
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,15 +79,10 @@ resource "aws_security_group" "ingress_all" {
   }
 }
 
-resource "aws_key_pair" "benchrun_keypair" {
-  key_name   = "bench-runner"
-  public_key = file("~/.ssh/id_rsa.pub")
-}
-
 resource "aws_instance" "bench_runner" {
   ami                    = "ami-830c94e3"
   instance_type          = "t2.micro"
-  key_name               = aws_key_pair.benchrun_keypair.key_name
+  key_name               = "bench-runner"
   vpc_security_group_ids = ["${aws_security_group.ingress_all.id}"]
   subnet_id              = aws_subnet.subnet1.id
 


### PR DESCRIPTION
# Overview

Initially I added requirements to get the benchrunner running, based on [Faster CPython's documentation](https://github.com/faster-cpython/bench_runner#benchmarking-tools-for-the-faster-cpython-project).

Since the self-hosted runner is not set up yet, I switched to getting it set up with GitHub Actions.

**CURRENT STATUS:** I set up a workflow and have configured AWS credentials with GitHub Actions, but am unsure how to go about running something on my own EC2 instance through this workflow.
- I have looked into [running commands using AWS Systems Manager](https://aws.amazon.com/getting-started/hands-on/remotely-run-commands-ec2-instance-systems-manager/) but I'm not sure if I'm on the right track.
- I noticed Faster CPython [recommends using bare metal machines rather than running the benchrunner on a cloud VM](https://github.com/faster-cpython/bench_runner/blob/main/PROVISIONING.md)
- I found a GitHub Action on the GitHub Marketplace that [can start EC2 self-hosted runners automatically in a workflow](https://github.com/marketplace/actions/on-demand-self-hosted-aws-ec2-runner-for-github-actions). Is this something I should look into?
- [This article](https://cloudonaut.io/self-hosted-github-runners-on-aws/) explains some options for self-hosted GitHub runners on AWS, but I'm having trouble locating documentation that goes into the details.

Any resources to help point me in the right direction would be appreciated!